### PR TITLE
[fix][broker] Return failed future instead of throwing exception in async methods

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
@@ -28,7 +28,6 @@ import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.pulsar.common.policies.data.OffloadPolicies;
-import org.apache.pulsar.common.util.FutureUtil;
 
 /**
  * Interface for offloading ledgers to long-term storage.
@@ -166,7 +165,7 @@ public interface LedgerOffloader {
     default CompletableFuture<OffloadHandle> streamingOffload(ManagedLedger ml, UUID uid, long beginLedger,
                                                               long beginEntry,
                                                               Map<String, String> driverMetadata) {
-        return FutureUtil.failedFuture(new UnsupportedOperationException());
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -201,11 +200,11 @@ public interface LedgerOffloader {
 
     default CompletableFuture<ReadHandle> readOffloaded(long ledgerId, MLDataFormats.OffloadContext ledgerContext,
                                                         Map<String, String> offloadDriverMetadata) {
-        return FutureUtil.failedFuture(new UnsupportedOperationException());
+        throw new UnsupportedOperationException();
     }
 
     default CompletableFuture<Void> deleteOffloaded(UUID uid, Map<String, String> offloadDriverMetadata) {
-        return FutureUtil.failedFuture(new UnsupportedOperationException());
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
@@ -28,6 +28,7 @@ import org.apache.bookkeeper.common.annotation.InterfaceAudience;
 import org.apache.bookkeeper.common.annotation.InterfaceStability;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.pulsar.common.policies.data.OffloadPolicies;
+import org.apache.pulsar.common.util.FutureUtil;
 
 /**
  * Interface for offloading ledgers to long-term storage.
@@ -165,7 +166,7 @@ public interface LedgerOffloader {
     default CompletableFuture<OffloadHandle> streamingOffload(ManagedLedger ml, UUID uid, long beginLedger,
                                                               long beginEntry,
                                                               Map<String, String> driverMetadata) {
-        throw new UnsupportedOperationException();
+        return FutureUtil.failedFuture(new UnsupportedOperationException());
     }
 
     /**
@@ -200,11 +201,11 @@ public interface LedgerOffloader {
 
     default CompletableFuture<ReadHandle> readOffloaded(long ledgerId, MLDataFormats.OffloadContext ledgerContext,
                                                         Map<String, String> offloadDriverMetadata) {
-        throw new UnsupportedOperationException();
+        return FutureUtil.failedFuture(new UnsupportedOperationException());
     }
 
     default CompletableFuture<Void> deleteOffloaded(UUID uid, Map<String, String> offloadDriverMetadata) {
-        throw new UnsupportedOperationException();
+        return FutureUtil.failedFuture(new UnsupportedOperationException());
     }
 
     /**

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -326,7 +326,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
     private CompletableFuture<Void> checkNamespace(Stream<String> namespaces) {
         boolean sameNamespace = namespaces.distinct().count() == 1;
         if (!sameNamespace) {
-            throw new IllegalArgumentException("The namespace should be the same");
+            return FutureUtil.failedFuture(new IllegalArgumentException("The namespace should be the same"));
         }
         return CompletableFuture.completedFuture(null);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -420,7 +420,8 @@ public class BrokersBase extends AdminResource {
 
     private CompletableFuture<Void> internalDeleteDynamicConfigurationOnMetadataAsync(String configName) {
         if (!pulsar().getBrokerService().isDynamicConfiguration(configName)) {
-            throw new RestException(Status.PRECONDITION_FAILED, "Can't delete non-dynamic configuration");
+            return FutureUtil.failedFuture(
+                    new RestException(Status.PRECONDITION_FAILED, "Can't delete non-dynamic configuration"));
         } else {
             return dynamicConfigurationResources().setDynamicConfigurationAsync(old -> {
                 if (old != null) {
@@ -536,4 +537,3 @@ public class BrokersBase extends AdminResource {
         return CompletableFuture.completedFuture(null);
     }
 }
-

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -748,7 +748,8 @@ public abstract class NamespacesBase extends AdminResource {
     private CompletableFuture<Void> checkNamespace(Stream<String> namespaces) {
         boolean sameNamespace = namespaces.distinct().count() == 1;
         if (!sameNamespace) {
-            throw new RestException(Status.BAD_REQUEST, "The namespace should be the same");
+            return FutureUtil.failedFuture(
+                    new RestException(Status.BAD_REQUEST, "The namespace should be the same"));
         }
         return CompletableFuture.completedFuture(null);
     }
@@ -1977,7 +1978,7 @@ public abstract class NamespacesBase extends AdminResource {
                     + " Repl clusters: %s, allowed clusters: %s",
                     ns.toString(), policies.replication_clusters, policies.allowed_clusters);
             log.info(msg);
-            throw new RestException(Status.BAD_REQUEST, msg);
+            return FutureUtil.failedFuture(new RestException(Status.BAD_REQUEST, msg));
         }
         pulsar().getBrokerService().setCurrentClusterAllowedIfNoClusterIsAllowed(ns, policies);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3777,8 +3777,8 @@ public class PersistentTopicsBase extends AdminResource {
 
     protected CompletableFuture<Void> internalSetMaxConsumers(Integer maxConsumersToSet, boolean isGlobal) {
         if (maxConsumersToSet != null && maxConsumersToSet < 0) {
-            throw new RestException(Status.PRECONDITION_FAILED,
-                    "maxConsumers must be 0 or more");
+            return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
+                    "maxConsumers must be 0 or more"));
         }
         return pulsar().getTopicPoliciesService()
                 .updateTopicPoliciesAsync(topicName, isGlobal, maxConsumersToSet == null, policies -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1074,8 +1074,8 @@ public class PersistentTopicsBase extends AdminResource {
     protected CompletableFuture<Void> internalSetMaxUnackedMessagesOnSubscription(Integer maxUnackedNumToSet,
                                                                                   boolean isGlobal) {
         if (maxUnackedNumToSet != null && maxUnackedNumToSet < 0) {
-            throw new RestException(Status.PRECONDITION_FAILED,
-                    "maxUnackedNum must be 0 or more");
+            return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
+                    "maxUnackedNum must be 0 or more"));
         }
 
         return pulsar().getTopicPoliciesService()
@@ -1099,8 +1099,8 @@ public class PersistentTopicsBase extends AdminResource {
     protected CompletableFuture<Void> internalSetMaxUnackedMessagesOnConsumer(Integer maxUnackedNumToSet,
                                                                               boolean isGlobal) {
         if (maxUnackedNumToSet != null && maxUnackedNumToSet < 0) {
-            throw new RestException(Status.PRECONDITION_FAILED,
-                    "maxUnackedNum must be 0 or more");
+            return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
+                    "maxUnackedNum must be 0 or more"));
         }
 
         return pulsar().getTopicPoliciesService()
@@ -1112,7 +1112,8 @@ public class PersistentTopicsBase extends AdminResource {
     protected CompletableFuture<Void> internalSetDeduplicationSnapshotInterval(Integer intervalToSet,
                                                                                boolean isGlobal) {
         if (intervalToSet != null && intervalToSet < 0) {
-            throw new RestException(Status.PRECONDITION_FAILED, "interval must be 0 or more");
+            return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
+                    "interval must be 0 or more"));
         }
         return pulsar().getTopicPoliciesService()
                 .updateTopicPoliciesAsync(topicName, isGlobal, intervalToSet == null, policies -> {
@@ -3643,9 +3644,9 @@ public class PersistentTopicsBase extends AdminResource {
     protected CompletableFuture<Void> internalSetMaxMessageSize(Integer maxMessageSizeToSet, boolean isGlobal) {
         if (maxMessageSizeToSet != null && (maxMessageSizeToSet < 0
                 || maxMessageSizeToSet > config().getMaxMessageSize())) {
-            throw new RestException(Status.PRECONDITION_FAILED
-                    , "topic-level maxMessageSize must be greater than or equal to 0 "
-                    + "and must be smaller than that in the broker-level");
+            return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
+                    "topic-level maxMessageSize must be greater than or equal to 0 "
+                            + "and must be smaller than that in the broker-level"));
         }
 
         return pulsar().getTopicPoliciesService()
@@ -3673,8 +3674,8 @@ public class PersistentTopicsBase extends AdminResource {
 
     protected CompletableFuture<Void> internalSetMaxProducers(Integer maxProducersToSet, boolean isGlobal) {
         if (maxProducersToSet != null && maxProducersToSet < 0) {
-            throw new RestException(Status.PRECONDITION_FAILED,
-                    "maxProducers must be 0 or more");
+            return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
+                    "maxProducers must be 0 or more"));
         }
         return pulsar().getTopicPoliciesService()
                 .updateTopicPoliciesAsync(topicName, isGlobal, maxProducersToSet == null, policies -> {
@@ -3690,8 +3691,8 @@ public class PersistentTopicsBase extends AdminResource {
     protected CompletableFuture<Void> internalSetMaxSubscriptionsPerTopic(Integer maxSubscriptionsToSet,
                                                                           boolean isGlobal) {
         if (maxSubscriptionsToSet != null && maxSubscriptionsToSet < 0) {
-            throw new RestException(Status.PRECONDITION_FAILED,
-                    "maxSubscriptionsPerTopic must be 0 or more");
+            return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
+                    "maxSubscriptionsPerTopic must be 0 or more"));
         }
 
         return pulsar().getTopicPoliciesService()
@@ -4678,7 +4679,7 @@ public class PersistentTopicsBase extends AdminResource {
                 futures.add(pulsar().getAdminClient().topics().trimTopicAsync(topicNamePartition.toString()));
             } catch (Exception e) {
                 log.error("[{}] Failed to trim topic {}", clientAppId(), topicNamePartition, e);
-                throw new RestException(e);
+                return FutureUtil.failedFuture(new RestException(e));
             }
         }
         return FutureUtil.waitForAll(futures).thenAccept(asyncResponse::resume);
@@ -4792,7 +4793,8 @@ public class PersistentTopicsBase extends AdminResource {
     protected CompletableFuture<Void> internalSetMaxConsumersPerSubscription(
             Integer maxConsumersPerSubscriptionToSet, boolean isGlobal) {
         if (maxConsumersPerSubscriptionToSet != null && maxConsumersPerSubscriptionToSet < 0) {
-            throw new RestException(Status.PRECONDITION_FAILED, "Invalid value for maxConsumersPerSubscription");
+            return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
+                    "Invalid value for maxConsumersPerSubscription"));
         }
         return pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, isGlobal, false, policies -> {
             policies.setMaxConsumersPerSubscription(maxConsumersPerSubscriptionToSet);
@@ -4821,7 +4823,8 @@ public class PersistentTopicsBase extends AdminResource {
 
     protected CompletableFuture<Void> internalSetCompactionThreshold(Long compactionThresholdToSet, boolean isGlobal) {
         if (compactionThresholdToSet != null && compactionThresholdToSet < 0) {
-            throw new RestException(Status.PRECONDITION_FAILED, "Invalid value for compactionThreshold");
+            return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
+                    "Invalid value for compactionThreshold"));
         }
 
         return pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, isGlobal, false, policies -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/Bucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/Bucket.java
@@ -23,7 +23,6 @@ import static org.apache.pulsar.broker.delayed.bucket.BucketDelayedDeliveryTrack
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import lombok.AllArgsConstructor;
@@ -158,7 +157,9 @@ abstract class Bucket {
     }
 
     private CompletableFuture<Void> putBucketKeyId(String bucketKey, Long bucketId) {
-        Objects.requireNonNull(bucketId);
+        if (bucketId == null) {
+            return FutureUtil.failedFuture(new NullPointerException());
+        }
         return sequencer.sequential(() -> {
             return executeWithRetry(() -> cursor.putCursorProperty(bucketKey, String.valueOf(bucketId)),
                     ManagedLedgerException.BadVersionException.class, MaxRetryTimes);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/Bucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/Bucket.java
@@ -158,7 +158,7 @@ abstract class Bucket {
 
     private CompletableFuture<Void> putBucketKeyId(String bucketKey, Long bucketId) {
         if (bucketId == null) {
-            return FutureUtil.failedFuture(new NullPointerException());
+            return FutureUtil.failedFuture(new NullPointerException("bucketId"));
         }
         return sequencer.sequential(() -> {
             return executeWithRetry(() -> cursor.putCursorProperty(bucketKey, String.valueOf(bucketId)),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/Bucket.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/bucket/Bucket.java
@@ -158,7 +158,7 @@ abstract class Bucket {
 
     private CompletableFuture<Void> putBucketKeyId(String bucketKey, Long bucketId) {
         if (bucketId == null) {
-            return FutureUtil.failedFuture(new NullPointerException("bucketId"));
+            return FutureUtil.failedFuture(new NullPointerException("Expected bucketId should not be null"));
         }
         return sequencer.sequential(() -> {
             return executeWithRetry(() -> cursor.putCursorProperty(bucketKey, String.valueOf(bucketId)),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
@@ -35,7 +35,6 @@ import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.common.naming.ServiceUnitId;
 import org.apache.pulsar.common.stats.Metrics;
-import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.Reflections;
 import org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport;
 import org.slf4j.Logger;
@@ -71,11 +70,11 @@ public interface LoadManager {
 
     default CompletableFuture<Optional<LookupResult>> findBrokerServiceUrl(
             Optional<ServiceUnitId> topic, ServiceUnitId bundle, LookupOptions options) {
-        return FutureUtil.failedFuture(new UnsupportedOperationException());
+        throw new UnsupportedOperationException();
     }
 
     default CompletableFuture<Boolean> checkOwnershipAsync(Optional<ServiceUnitId> topic, ServiceUnitId bundle) {
-        return FutureUtil.failedFuture(new UnsupportedOperationException());
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.common.naming.ServiceUnitId;
 import org.apache.pulsar.common.stats.Metrics;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.Reflections;
 import org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport;
 import org.slf4j.Logger;
@@ -70,11 +71,11 @@ public interface LoadManager {
 
     default CompletableFuture<Optional<LookupResult>> findBrokerServiceUrl(
             Optional<ServiceUnitId> topic, ServiceUnitId bundle, LookupOptions options) {
-        return CompletableFuture.failedFuture(new UnsupportedOperationException());
+        return FutureUtil.failedFuture(new UnsupportedOperationException());
     }
 
     default CompletableFuture<Boolean> checkOwnershipAsync(Optional<ServiceUnitId> topic, ServiceUnitId bundle) {
-        return CompletableFuture.failedFuture(new UnsupportedOperationException());
+        return FutureUtil.failedFuture(new UnsupportedOperationException());
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
@@ -70,11 +70,11 @@ public interface LoadManager {
 
     default CompletableFuture<Optional<LookupResult>> findBrokerServiceUrl(
             Optional<ServiceUnitId> topic, ServiceUnitId bundle, LookupOptions options) {
-        throw new UnsupportedOperationException();
+        return CompletableFuture.failedFuture(new UnsupportedOperationException());
     }
 
     default CompletableFuture<Boolean> checkOwnershipAsync(Optional<ServiceUnitId> topic, ServiceUnitId bundle) {
-        throw new UnsupportedOperationException();
+        return CompletableFuture.failedFuture(new UnsupportedOperationException());
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -671,7 +671,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
     private CompletableFuture<Void> publishOverrideEventAsync(String serviceUnit,
                                                               ServiceUnitStateData override) {
         if (!validateChannelState(Started, true)) {
-            throw new IllegalStateException("Invalid channel state:" + channelState.name());
+            return FutureUtil.failedFuture(new IllegalStateException("Invalid channel state:" + channelState.name()));
         }
         EventType eventType = EventType.Override;
         eventCounters.get(eventType).getTotal().incrementAndGet();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1145,8 +1145,12 @@ public class NamespaceService implements AutoCloseable {
      */
     public CompletableFuture<Void> updateNamespaceBundlesForPolicies(NamespaceName nsname,
                                                                       NamespaceBundles nsBundles) {
-        Objects.requireNonNull(nsname);
-        Objects.requireNonNull(nsBundles);
+        if (nsname == null) {
+            return FutureUtil.failedFuture(new NullPointerException("Excepted NamespaceName should not be null "));
+        }
+        if (nsBundles == null) {
+            return FutureUtil.failedFuture(new NullPointerException("nsBundles"));
+        }
 
         return pulsar.getPulsarResources().getNamespaceResources().getPoliciesAsync(nsname).thenCompose(policies -> {
             if (policies.isPresent()) {
@@ -1172,8 +1176,12 @@ public class NamespaceService implements AutoCloseable {
      * @param nsBundles the new namespace bundles
      */
     public CompletableFuture<Void> updateNamespaceBundles(NamespaceName nsname, NamespaceBundles nsBundles) {
-        Objects.requireNonNull(nsname);
-        Objects.requireNonNull(nsBundles);
+        if (nsname == null) {
+            return FutureUtil.failedFuture(new NullPointerException("Expected NamespaceName should not be null"));
+        }
+        if (nsBundles == null) {
+            return FutureUtil.failedFuture(new NullPointerException("Expected NamespaceBundles should not be null"));
+        }
 
         LocalPolicies localPolicies = nsBundles.toLocalPolicies();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1146,7 +1146,7 @@ public class NamespaceService implements AutoCloseable {
     public CompletableFuture<Void> updateNamespaceBundlesForPolicies(NamespaceName nsname,
                                                                       NamespaceBundles nsBundles) {
         if (nsname == null) {
-            return FutureUtil.failedFuture(new NullPointerException("Excepted NamespaceName should not be null "));
+            return FutureUtil.failedFuture(new NullPointerException("Expected NamespaceName should not be null"));
         }
         if (nsBundles == null) {
             return FutureUtil.failedFuture(new NullPointerException("nsBundles"));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1149,7 +1149,7 @@ public class NamespaceService implements AutoCloseable {
             return FutureUtil.failedFuture(new NullPointerException("Expected NamespaceName should not be null"));
         }
         if (nsBundles == null) {
-            return FutureUtil.failedFuture(new NullPointerException("nsBundles"));
+            return FutureUtil.failedFuture(new NullPointerException("Expected NamespaceBundles should not be null"));
         }
 
         return pulsar.getPulsarResources().getNamespaceResources().getPoliciesAsync(nsname).thenCompose(policies -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.service;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.bookkeeper.mledger.ManagedLedgerConfig.PROPERTY_SOURCE_TOPIC_KEY;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2011,7 +2011,9 @@ public class BrokerService implements Closeable {
     }
 
     public CompletableFuture<ManagedLedgerConfig> getManagedLedgerConfig(@NonNull TopicName topicName) {
-        requireNonNull(topicName);
+        if (topicName == null) {
+            return FutureUtil.failedFuture(new NullPointerException("topicName"));
+        }
         NamespaceName namespace = topicName.getNamespaceObject();
         ServiceConfiguration serviceConfig = pulsar.getConfiguration();
 
@@ -3433,10 +3435,15 @@ public class BrokerService implements Closeable {
                                                                                         Optional<Policies> policies) {
         final int defaultNumPartitions = pulsar.getBrokerService().getDefaultNumPartitions(topicName, policies);
         final int maxPartitions = pulsar().getConfig().getMaxNumPartitionsPerPartitionedTopic();
-        checkArgument(defaultNumPartitions > 0,
-                "Default number of partitions should be more than 0");
-        checkArgument(maxPartitions <= 0 || defaultNumPartitions <= maxPartitions,
-                "Number of partitions should be less than or equal to " + maxPartitions);
+        if (defaultNumPartitions <= 0) {
+            return FutureUtil.failedFuture(
+                    new IllegalArgumentException("Default number of partitions should be more than 0"));
+        }
+        if (maxPartitions > 0 && defaultNumPartitions > maxPartitions) {
+            return FutureUtil.failedFuture(
+                    new IllegalArgumentException("Number of partitions should be less than or equal to "
+                            + maxPartitions));
+        }
 
         PartitionedTopicMetadata configMetadata = new PartitionedTopicMetadata(defaultNumPartitions);
 
@@ -3746,7 +3753,9 @@ public class BrokerService implements Closeable {
     }
 
     public @NonNull CompletableFuture<Boolean> isAllowAutoSubscriptionCreationAsync(@NonNull TopicName tpName) {
-        requireNonNull(tpName);
+        if (tpName == null) {
+            return FutureUtil.failedFuture(new NullPointerException("tpName"));
+        }
         // Policies priority: topic level -> namespace level -> broker level
         if (ExtensibleLoadManagerImpl.isInternalTopic(tpName.toString())) {
             return CompletableFuture.completedFuture(true);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/SystemTopicBasedTopicPoliciesService.java
@@ -565,7 +565,9 @@ public class SystemTopicBasedTopicPoliciesService implements TopicPoliciesServic
 
     @VisibleForTesting
     @NonNull CompletableFuture<Boolean> prepareInitPoliciesCacheAsync(@NonNull NamespaceName namespace) {
-        requireNonNull(namespace);
+        if (namespace == null) {
+            return FutureUtil.failedFuture(new NullPointerException("Expected NamespaceName should not be null"));
+        }
         if (closed.get()) {
             return CompletableFuture.completedFuture(false);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -291,7 +291,8 @@ public interface Topic {
      * Get the last message position that can be dispatch.
      */
     default CompletableFuture<Position> getLastDispatchablePosition() {
-        throw new UnsupportedOperationException("getLastDispatchablePosition is not supported by default");
+        return CompletableFuture.failedFuture(
+                new UnsupportedOperationException("getLastDispatchablePosition is not supported by default"));
     }
 
     CompletableFuture<MessageId> getLastMessageId();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -44,6 +44,7 @@ import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.stats.TopicStatsImpl;
 import org.apache.pulsar.common.protocol.schema.SchemaData;
 import org.apache.pulsar.common.protocol.schema.SchemaVersion;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
 import org.apache.pulsar.utils.StatsOutputStream;
 
@@ -291,7 +292,7 @@ public interface Topic {
      * Get the last message position that can be dispatch.
      */
     default CompletableFuture<Position> getLastDispatchablePosition() {
-        return CompletableFuture.failedFuture(
+        return FutureUtil.failedFuture(
                 new UnsupportedOperationException("getLastDispatchablePosition is not supported by default"));
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -1218,7 +1218,8 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
 
     @Override
     public CompletableFuture<MessageId> getLastMessageId() {
-        throw new UnsupportedOperationException("getLastMessageId is not supported on non-persistent topic");
+        return CompletableFuture.failedFuture(
+                new UnsupportedOperationException("getLastMessageId is not supported on non-persistent topic"));
     }
 
     private static final Logger log = LoggerFactory.getLogger(NonPersistentTopic.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -1218,7 +1218,7 @@ public class NonPersistentTopic extends AbstractTopic implements Topic, TopicPol
 
     @Override
     public CompletableFuture<MessageId> getLastMessageId() {
-        return CompletableFuture.failedFuture(
+        return FutureUtil.failedFuture(
                 new UnsupportedOperationException("getLastMessageId is not supported on non-persistent topic"));
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -60,6 +60,7 @@ import org.apache.pulsar.broker.storage.BookkeeperManagedLedgerStorageClass;
 import org.apache.pulsar.broker.storage.ManagedLedgerStorageClass;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.stats.Metrics;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.SimpleTextOutputStream;
 
 /**
@@ -139,7 +140,7 @@ public class PrometheusMetricsGenerator implements AutoCloseable {
 
         public synchronized CompletableFuture<ByteBuf> getCompressedBuffer(Executor executor) {
             if (released) {
-                throw new IllegalStateException("Already released!");
+                return FutureUtil.failedFuture(new IllegalStateException("Already released!"));
             }
             if (compressedBuffer == null) {
                 compressedBuffer = new CompletableFuture<>();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
@@ -123,7 +123,7 @@ public interface SystemTopicClient<T> {
          * @return message id future
          */
         default CompletableFuture<MessageId> deleteAsync(String key, T t) {
-            throw new UnsupportedOperationException("Unsupported operation");
+            return CompletableFuture.failedFuture(new UnsupportedOperationException("Unsupported operation"));
         }
 
         /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/systopic/SystemTopicClient.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.util.FutureUtil;
 
 /**
  * Pulsar system topic.
@@ -123,7 +124,7 @@ public interface SystemTopicClient<T> {
          * @return message id future
          */
         default CompletableFuture<MessageId> deleteAsync(String key, T t) {
-            return CompletableFuture.failedFuture(new UnsupportedOperationException("Unsupported operation"));
+            return FutureUtil.failedFuture(new UnsupportedOperationException("Unsupported operation"));
         }
 
         /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -186,14 +186,12 @@ public abstract class PulsarWebResource {
         return appId != null;
     }
 
-    private CompletableFuture<Void> validateOriginalPrincipalAsync(String authenticatedPrincipal,
-                                                                   String originalPrincipal) {
+    private void validateOriginalPrincipal(String authenticatedPrincipal, String originalPrincipal) {
         if (!pulsar.getBrokerService().getAuthorizationService()
                 .isValidOriginalPrincipal(authenticatedPrincipal, originalPrincipal, clientAuthData())) {
-            return FutureUtil.failedFuture(new RestException(Status.UNAUTHORIZED,
-                    "Invalid combination of Original principal cannot be empty if the request is via proxy."));
+            throw new RestException(Status.UNAUTHORIZED,
+                    "Invalid combination of Original principal cannot be empty if the request is via proxy.");
         }
-        return CompletableFuture.completedFuture(null);
     }
 
     protected boolean hasSuperUserAccess() {
@@ -215,46 +213,42 @@ public abstract class PulsarWebResource {
                     isClientAuthenticated(appId), appId);
         }
         String originalPrincipal = originalPrincipal();
-        return validateOriginalPrincipalAsync(appId, originalPrincipal)
-                .thenCompose(__ -> {
-                    if (pulsar.getConfiguration().getProxyRoles().contains(appId)) {
-                        BrokerService brokerService = pulsar.getBrokerService();
-                        return brokerService.getAuthorizationService().isSuperUser(appId, clientAuthData())
-                                .thenCompose(proxyAuthorizationSuccess -> {
-                                    if (!proxyAuthorizationSuccess) {
-                                        return FutureUtil.failedFuture(new RestException(Status.UNAUTHORIZED,
-                                                String.format("Proxy not authorized for super-user "
-                                                        + "operation (proxy:%s)", appId)));
-                                    }
-                                    return pulsar.getBrokerService()
-                                            .getAuthorizationService()
-                                            .isSuperUser(originalPrincipal, clientAuthData());
-                                }).thenCompose(originalPrincipalAuthorizationSuccess -> {
-                                    if (!originalPrincipalAuthorizationSuccess) {
-                                        return FutureUtil.failedFuture(new RestException(Status.UNAUTHORIZED,
-                                                String.format(
-                                                        "Original principal not authorized for super-user operation "
-                                                                + "(original:%s)", originalPrincipal)));
-                                    }
-                                    if (log.isDebugEnabled()) {
-                                        log.debug("Successfully authorized {} (proxied by {}) as super-user",
-                                                originalPrincipal, appId);
-                                    }
-                                    return CompletableFuture.completedFuture(null);
-                                });
-                    } else {
+        validateOriginalPrincipal(appId, originalPrincipal);
+
+        if (pulsar.getConfiguration().getProxyRoles().contains(appId)) {
+            BrokerService brokerService = pulsar.getBrokerService();
+            return brokerService.getAuthorizationService().isSuperUser(appId, clientAuthData())
+                    .thenCompose(proxyAuthorizationSuccess -> {
+                        if (!proxyAuthorizationSuccess){
+                            throw new RestException(Status.UNAUTHORIZED,
+                                    String.format("Proxy not authorized for super-user "
+                                            + "operation (proxy:%s)", appId));
+                        }
                         return pulsar.getBrokerService()
                                 .getAuthorizationService()
-                                .isSuperUser(appId, clientAuthData())
-                                .thenCompose(proxyAuthorizationSuccess -> {
-                                    if (!proxyAuthorizationSuccess) {
-                                        return FutureUtil.failedFuture(new RestException(Status.UNAUTHORIZED,
-                                                "This operation requires super-user access"));
-                                    }
-                                    return CompletableFuture.completedFuture(null);
-                                });
-                    }
-                });
+                                .isSuperUser(originalPrincipal, clientAuthData());
+                    }).thenAccept(originalPrincipalAuthorizationSuccess -> {
+                        if (!originalPrincipalAuthorizationSuccess){
+                            throw new RestException(Status.UNAUTHORIZED,
+                                    String.format("Original principal not authorized for super-user operation "
+                                                    + "(original:%s)", originalPrincipal));
+                        }
+                        if (log.isDebugEnabled()) {
+                            log.debug("Successfully authorized {} (proxied by {}) as super-user",
+                                    originalPrincipal, appId);
+                        }
+                    });
+        } else {
+            return pulsar.getBrokerService()
+                    .getAuthorizationService()
+                    .isSuperUser(appId, clientAuthData())
+                    .thenAccept(proxyAuthorizationSuccess -> {
+                        if (!proxyAuthorizationSuccess) {
+                            throw new RestException(Status.UNAUTHORIZED,
+                                    "This operation requires super-user access");
+                        }
+                    });
+        }
     }
 
     /**
@@ -325,88 +319,67 @@ public abstract class PulsarWebResource {
         return pulsar.getPulsarResources().getTenantResources().getTenantAsync(tenant)
                 .thenCompose(tenantInfoOptional -> {
                     if (tenantInfoOptional.isEmpty()) {
-                        return FutureUtil.failedFuture(new RestException(Status.NOT_FOUND, "Tenant does not exist"));
+                        throw new RestException(Status.NOT_FOUND, "Tenant does not exist");
                     }
                     TenantInfo tenantInfo = tenantInfoOptional.get();
                     if (pulsar.getConfiguration().isAuthenticationEnabled() && pulsar.getConfiguration()
                             .isAuthorizationEnabled()) {
                         if (!isClientAuthenticated(clientAppId)) {
-                            return FutureUtil.failedFuture(new RestException(Status.FORBIDDEN,
-                                    "Need to authenticate to perform the request"));
+                            throw new RestException(Status.FORBIDDEN, "Need to authenticate to perform the request");
                         }
-                        return validateOriginalPrincipalAsync(clientAppId, originalPrincipal)
-                                .thenCompose(__ -> {
-                                    if (pulsar.getConfiguration().getProxyRoles().contains(clientAppId)) {
-                                        AuthorizationService authorizationService =
-                                                pulsar.getBrokerService().getAuthorizationService();
-                                        return authorizationService.isTenantAdmin(tenant, clientAppId, tenantInfo,
-                                                        authenticationData)
-                                                .thenCompose(isTenantAdmin -> {
-                                                    String debugMsg =
-                                                            "Successfully authorized {} (proxied by {}) on tenant {}";
-                                                    if (!isTenantAdmin) {
-                                                        return authorizationService.isSuperUser(clientAppId,
-                                                                        authenticationData)
-                                                                .thenCombine(
-                                                                        authorizationService.isSuperUser(
-                                                                                originalPrincipal,
-                                                                                authenticationData),
-                                                                        (proxyAuthorized, originalPrincipalAuthorized)
-                                                                                -> proxyAuthorized
-                                                                                && originalPrincipalAuthorized)
-                                                                .thenCompose(authorized -> {
-                                                                    if (!authorized) {
-                                                                        String errorMsg =
-                                                                                "Proxy not authorized to access "
-                                                                                        + "resource (proxy:%s,"
-                                                                                        + "original:%s)";
-                                                                        return FutureUtil.failedFuture(
-                                                                                new RestException(
-                                                                                        Status.UNAUTHORIZED,
-                                                                                        String.format(errorMsg,
-                                                                                                clientAppId,
-                                                                                                originalPrincipal)));
-                                                                    }
-                                                                    if (log.isDebugEnabled()) {
-                                                                        log.debug(debugMsg, originalPrincipal,
-                                                                                clientAppId, tenant);
-                                                                    }
-                                                                    return CompletableFuture.completedFuture(null);
-                                                                });
-                                                    } else {
-                                                        if (log.isDebugEnabled()) {
-                                                            log.debug(debugMsg, originalPrincipal, clientAppId, tenant);
-                                                        }
-                                                        return CompletableFuture.completedFuture(null);
-                                                    }
-                                                });
+                        validateOriginalPrincipal(clientAppId, originalPrincipal);
+                        if (pulsar.getConfiguration().getProxyRoles().contains(clientAppId)) {
+                            AuthorizationService authorizationService =
+                                    pulsar.getBrokerService().getAuthorizationService();
+                            return authorizationService.isTenantAdmin(tenant, clientAppId, tenantInfo,
+                                            authenticationData)
+                                .thenCompose(isTenantAdmin -> {
+                                    String debugMsg = "Successfully authorized {} (proxied by {}) on tenant {}";
+                                    if (!isTenantAdmin) {
+                                            return authorizationService.isSuperUser(clientAppId, authenticationData)
+                                                .thenCombine(authorizationService.isSuperUser(originalPrincipal,
+                                                             authenticationData),
+                                                     (proxyAuthorized, originalPrincipalAuthorized) -> {
+                                                         if (!proxyAuthorized || !originalPrincipalAuthorized) {
+                                                             throw new RestException(Status.UNAUTHORIZED,
+                                                                     String.format("Proxy not authorized to access "
+                                                                                     + "resource (proxy:%s,original:%s)"
+                                                                             , clientAppId, originalPrincipal));
+                                                         } else {
+                                                             if (log.isDebugEnabled()) {
+                                                                 log.debug(debugMsg, originalPrincipal, clientAppId,
+                                                                         tenant);
+                                                             }
+                                                             return null;
+                                                         }
+                                                     });
                                     } else {
-                                        return pulsar.getBrokerService()
-                                                .getAuthorizationService()
-                                                .isSuperUser(clientAppId, authenticationData)
-                                                .thenCompose(isSuperUser -> {
-                                                    if (!isSuperUser) {
-                                                        return pulsar.getBrokerService().getAuthorizationService()
-                                                                .isTenantAdmin(tenant, clientAppId, tenantInfo,
-                                                                        authenticationData);
-                                                    } else {
-                                                        return CompletableFuture.completedFuture(true);
-                                                    }
-                                                }).thenCompose(authorized -> {
-                                                    if (!authorized) {
-                                                        return FutureUtil.failedFuture(
-                                                                new RestException(Status.UNAUTHORIZED,
-                                                                        "Don't have permission to administrate "
-                                                                                + "resources "
-                                                                                + "on this tenant"));
-                                                    } else {
-                                                        log.debug("Successfully authorized {} on tenant {}",
-                                                                clientAppId, tenant);
-                                                        return CompletableFuture.completedFuture(null);
-                                                    }
-                                                });
+                                        if (log.isDebugEnabled()) {
+                                            log.debug(debugMsg, originalPrincipal, clientAppId, tenant);
+                                        }
+                                        return CompletableFuture.completedFuture(null);
                                     }
                                 });
+                        } else {
+                            return pulsar.getBrokerService()
+                                    .getAuthorizationService()
+                                    .isSuperUser(clientAppId, authenticationData)
+                                    .thenCompose(isSuperUser -> {
+                                        if (!isSuperUser) {
+                                            return pulsar.getBrokerService().getAuthorizationService()
+                                                    .isTenantAdmin(tenant, clientAppId, tenantInfo, authenticationData);
+                                        } else {
+                                            return CompletableFuture.completedFuture(true);
+                                        }
+                                    }).thenAccept(authorized -> {
+                                        if (!authorized) {
+                                            throw new RestException(Status.UNAUTHORIZED,
+                                                    "Don't have permission to administrate resources on this tenant");
+                                        } else {
+                                            log.debug("Successfully authorized {} on tenant {}", clientAppId, tenant);
+                                        }
+                                    });
+                        }
                     } else {
                         return CompletableFuture.completedFuture(null);
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -186,12 +186,14 @@ public abstract class PulsarWebResource {
         return appId != null;
     }
 
-    private void validateOriginalPrincipal(String authenticatedPrincipal, String originalPrincipal) {
+    private CompletableFuture<Void> validateOriginalPrincipalAsync(String authenticatedPrincipal,
+                                                                   String originalPrincipal) {
         if (!pulsar.getBrokerService().getAuthorizationService()
                 .isValidOriginalPrincipal(authenticatedPrincipal, originalPrincipal, clientAuthData())) {
-            throw new RestException(Status.UNAUTHORIZED,
-                    "Invalid combination of Original principal cannot be empty if the request is via proxy.");
+            return FutureUtil.failedFuture(new RestException(Status.UNAUTHORIZED,
+                    "Invalid combination of Original principal cannot be empty if the request is via proxy."));
         }
+        return CompletableFuture.completedFuture(null);
     }
 
     protected boolean hasSuperUserAccess() {
@@ -213,42 +215,44 @@ public abstract class PulsarWebResource {
                     isClientAuthenticated(appId), appId);
         }
         String originalPrincipal = originalPrincipal();
-        validateOriginalPrincipal(appId, originalPrincipal);
-
-        if (pulsar.getConfiguration().getProxyRoles().contains(appId)) {
-            BrokerService brokerService = pulsar.getBrokerService();
-            return brokerService.getAuthorizationService().isSuperUser(appId, clientAuthData())
-                    .thenCompose(proxyAuthorizationSuccess -> {
-                        if (!proxyAuthorizationSuccess){
-                            throw new RestException(Status.UNAUTHORIZED,
-                                    String.format("Proxy not authorized for super-user "
-                                            + "operation (proxy:%s)", appId));
-                        }
+        return validateOriginalPrincipalAsync(appId, originalPrincipal)
+                .thenCompose(__ -> {
+                    if (pulsar.getConfiguration().getProxyRoles().contains(appId)) {
+                        BrokerService brokerService = pulsar.getBrokerService();
+                        return brokerService.getAuthorizationService().isSuperUser(appId, clientAuthData())
+                                .thenCompose(proxyAuthorizationSuccess -> {
+                                    if (!proxyAuthorizationSuccess) {
+                                        throw new RestException(Status.UNAUTHORIZED,
+                                                String.format("Proxy not authorized for super-user "
+                                                        + "operation (proxy:%s)", appId));
+                                    }
+                                    return pulsar.getBrokerService()
+                                            .getAuthorizationService()
+                                            .isSuperUser(originalPrincipal, clientAuthData());
+                                }).thenAccept(originalPrincipalAuthorizationSuccess -> {
+                                    if (!originalPrincipalAuthorizationSuccess) {
+                                        throw new RestException(Status.UNAUTHORIZED,
+                                                String.format(
+                                                        "Original principal not authorized for super-user operation "
+                                                                + "(original:%s)", originalPrincipal));
+                                    }
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("Successfully authorized {} (proxied by {}) as super-user",
+                                                originalPrincipal, appId);
+                                    }
+                                });
+                    } else {
                         return pulsar.getBrokerService()
                                 .getAuthorizationService()
-                                .isSuperUser(originalPrincipal, clientAuthData());
-                    }).thenAccept(originalPrincipalAuthorizationSuccess -> {
-                        if (!originalPrincipalAuthorizationSuccess){
-                            throw new RestException(Status.UNAUTHORIZED,
-                                    String.format("Original principal not authorized for super-user operation "
-                                                    + "(original:%s)", originalPrincipal));
-                        }
-                        if (log.isDebugEnabled()) {
-                            log.debug("Successfully authorized {} (proxied by {}) as super-user",
-                                    originalPrincipal, appId);
-                        }
-                    });
-        } else {
-            return pulsar.getBrokerService()
-                    .getAuthorizationService()
-                    .isSuperUser(appId, clientAuthData())
-                    .thenAccept(proxyAuthorizationSuccess -> {
-                        if (!proxyAuthorizationSuccess) {
-                            throw new RestException(Status.UNAUTHORIZED,
-                                    "This operation requires super-user access");
-                        }
-                    });
-        }
+                                .isSuperUser(appId, clientAuthData())
+                                .thenAccept(proxyAuthorizationSuccess -> {
+                                    if (!proxyAuthorizationSuccess) {
+                                        throw new RestException(Status.UNAUTHORIZED,
+                                                "This operation requires super-user access");
+                                    }
+                                });
+                    }
+                });
     }
 
     /**
@@ -327,59 +331,77 @@ public abstract class PulsarWebResource {
                         if (!isClientAuthenticated(clientAppId)) {
                             throw new RestException(Status.FORBIDDEN, "Need to authenticate to perform the request");
                         }
-                        validateOriginalPrincipal(clientAppId, originalPrincipal);
-                        if (pulsar.getConfiguration().getProxyRoles().contains(clientAppId)) {
-                            AuthorizationService authorizationService =
-                                    pulsar.getBrokerService().getAuthorizationService();
-                            return authorizationService.isTenantAdmin(tenant, clientAppId, tenantInfo,
-                                            authenticationData)
-                                .thenCompose(isTenantAdmin -> {
-                                    String debugMsg = "Successfully authorized {} (proxied by {}) on tenant {}";
-                                    if (!isTenantAdmin) {
-                                            return authorizationService.isSuperUser(clientAppId, authenticationData)
-                                                .thenCombine(authorizationService.isSuperUser(originalPrincipal,
-                                                             authenticationData),
-                                                     (proxyAuthorized, originalPrincipalAuthorized) -> {
-                                                         if (!proxyAuthorized || !originalPrincipalAuthorized) {
-                                                             throw new RestException(Status.UNAUTHORIZED,
-                                                                     String.format("Proxy not authorized to access "
-                                                                                     + "resource (proxy:%s,original:%s)"
-                                                                             , clientAppId, originalPrincipal));
-                                                         } else {
-                                                             if (log.isDebugEnabled()) {
-                                                                 log.debug(debugMsg, originalPrincipal, clientAppId,
-                                                                         tenant);
-                                                             }
-                                                             return null;
-                                                         }
-                                                     });
+                        return validateOriginalPrincipalAsync(clientAppId, originalPrincipal)
+                                .thenCompose(__ -> {
+                                    if (pulsar.getConfiguration().getProxyRoles().contains(clientAppId)) {
+                                        AuthorizationService authorizationService =
+                                                pulsar.getBrokerService().getAuthorizationService();
+                                        return authorizationService.isTenantAdmin(tenant, clientAppId, tenantInfo,
+                                                        authenticationData)
+                                                .thenCompose(isTenantAdmin -> {
+                                                    String debugMsg =
+                                                            "Successfully authorized {} (proxied by {}) on tenant {}";
+                                                    if (!isTenantAdmin) {
+                                                        return authorizationService.isSuperUser(clientAppId,
+                                                                        authenticationData)
+                                                                .thenCombine(authorizationService.isSuperUser(
+                                                                                originalPrincipal,
+                                                                                authenticationData),
+                                                                        (proxyAuthorized,
+                                                                         originalPrincipalAuthorized) -> {
+                                                                            if (!proxyAuthorized
+                                                                                    || !originalPrincipalAuthorized) {
+                                                                                throw new RestException(
+                                                                                        Status.UNAUTHORIZED,
+                                                                                        String.format(
+                                                                                                "Proxy not authorized"
+                                                                                                        + " to access "
+                                                                                                        + "resource "
+                                                                                                        + "(proxy:%s,"
+                                                                                                        + "original:%s)"
+                                                                                                , clientAppId,
+                                                                                                originalPrincipal));
+                                                                            } else {
+                                                                                if (log.isDebugEnabled()) {
+                                                                                    log.debug(debugMsg,
+                                                                                            originalPrincipal,
+                                                                                            clientAppId,
+                                                                                            tenant);
+                                                                                }
+                                                                                return null;
+                                                                            }
+                                                                        });
+                                                    } else {
+                                                        if (log.isDebugEnabled()) {
+                                                            log.debug(debugMsg, originalPrincipal, clientAppId, tenant);
+                                                        }
+                                                        return CompletableFuture.completedFuture(null);
+                                                    }
+                                                });
                                     } else {
-                                        if (log.isDebugEnabled()) {
-                                            log.debug(debugMsg, originalPrincipal, clientAppId, tenant);
-                                        }
-                                        return CompletableFuture.completedFuture(null);
+                                        return pulsar.getBrokerService()
+                                                .getAuthorizationService()
+                                                .isSuperUser(clientAppId, authenticationData)
+                                                .thenCompose(isSuperUser -> {
+                                                    if (!isSuperUser) {
+                                                        return pulsar.getBrokerService().getAuthorizationService()
+                                                                .isTenantAdmin(tenant, clientAppId, tenantInfo,
+                                                                        authenticationData);
+                                                    } else {
+                                                        return CompletableFuture.completedFuture(true);
+                                                    }
+                                                }).thenAccept(authorized -> {
+                                                    if (!authorized) {
+                                                        throw new RestException(Status.UNAUTHORIZED,
+                                                                "Don't have permission to administrate resources on "
+                                                                        + "this tenant");
+                                                    } else {
+                                                        log.debug("Successfully authorized {} on tenant {}",
+                                                                clientAppId, tenant);
+                                                    }
+                                                });
                                     }
                                 });
-                        } else {
-                            return pulsar.getBrokerService()
-                                    .getAuthorizationService()
-                                    .isSuperUser(clientAppId, authenticationData)
-                                    .thenCompose(isSuperUser -> {
-                                        if (!isSuperUser) {
-                                            return pulsar.getBrokerService().getAuthorizationService()
-                                                    .isTenantAdmin(tenant, clientAppId, tenantInfo, authenticationData);
-                                        } else {
-                                            return CompletableFuture.completedFuture(true);
-                                        }
-                                    }).thenAccept(authorized -> {
-                                        if (!authorized) {
-                                            throw new RestException(Status.UNAUTHORIZED,
-                                                    "Don't have permission to administrate resources on this tenant");
-                                        } else {
-                                            log.debug("Successfully authorized {} on tenant {}", clientAppId, tenant);
-                                        }
-                                    });
-                        }
                     } else {
                         return CompletableFuture.completedFuture(null);
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -186,14 +186,12 @@ public abstract class PulsarWebResource {
         return appId != null;
     }
 
-    private CompletableFuture<Void> validateOriginalPrincipalAsync(String authenticatedPrincipal,
-                                                                   String originalPrincipal) {
+    private void validateOriginalPrincipal(String authenticatedPrincipal, String originalPrincipal) {
         if (!pulsar.getBrokerService().getAuthorizationService()
                 .isValidOriginalPrincipal(authenticatedPrincipal, originalPrincipal, clientAuthData())) {
-            return FutureUtil.failedFuture(new RestException(Status.UNAUTHORIZED,
-                    "Invalid combination of Original principal cannot be empty if the request is via proxy."));
+            throw new RestException(Status.UNAUTHORIZED,
+                    "Invalid combination of Original principal cannot be empty if the request is via proxy.");
         }
-        return CompletableFuture.completedFuture(null);
     }
 
     protected boolean hasSuperUserAccess() {
@@ -215,44 +213,46 @@ public abstract class PulsarWebResource {
                     isClientAuthenticated(appId), appId);
         }
         String originalPrincipal = originalPrincipal();
-        return validateOriginalPrincipalAsync(appId, originalPrincipal)
-                .thenCompose(__ -> {
-                    if (pulsar.getConfiguration().getProxyRoles().contains(appId)) {
-                        BrokerService brokerService = pulsar.getBrokerService();
-                        return brokerService.getAuthorizationService().isSuperUser(appId, clientAuthData())
-                                .thenCompose(proxyAuthorizationSuccess -> {
-                                    if (!proxyAuthorizationSuccess) {
-                                        throw new RestException(Status.UNAUTHORIZED,
-                                                String.format("Proxy not authorized for super-user "
-                                                        + "operation (proxy:%s)", appId));
-                                    }
-                                    return pulsar.getBrokerService()
-                                            .getAuthorizationService()
-                                            .isSuperUser(originalPrincipal, clientAuthData());
-                                }).thenAccept(originalPrincipalAuthorizationSuccess -> {
-                                    if (!originalPrincipalAuthorizationSuccess) {
-                                        throw new RestException(Status.UNAUTHORIZED,
-                                                String.format(
-                                                        "Original principal not authorized for super-user operation "
-                                                                + "(original:%s)", originalPrincipal));
-                                    }
-                                    if (log.isDebugEnabled()) {
-                                        log.debug("Successfully authorized {} (proxied by {}) as super-user",
-                                                originalPrincipal, appId);
-                                    }
-                                });
-                    } else {
+        try {
+            validateOriginalPrincipal(appId, originalPrincipal);
+        } catch (RestException e) {
+            return FutureUtil.failedFuture(e);
+        }
+
+        if (pulsar.getConfiguration().getProxyRoles().contains(appId)) {
+            BrokerService brokerService = pulsar.getBrokerService();
+            return brokerService.getAuthorizationService().isSuperUser(appId, clientAuthData())
+                    .thenCompose(proxyAuthorizationSuccess -> {
+                        if (!proxyAuthorizationSuccess){
+                            throw new RestException(Status.UNAUTHORIZED,
+                                    String.format("Proxy not authorized for super-user "
+                                            + "operation (proxy:%s)", appId));
+                        }
                         return pulsar.getBrokerService()
                                 .getAuthorizationService()
-                                .isSuperUser(appId, clientAuthData())
-                                .thenAccept(proxyAuthorizationSuccess -> {
-                                    if (!proxyAuthorizationSuccess) {
-                                        throw new RestException(Status.UNAUTHORIZED,
-                                                "This operation requires super-user access");
-                                    }
-                                });
-                    }
-                });
+                                .isSuperUser(originalPrincipal, clientAuthData());
+                    }).thenAccept(originalPrincipalAuthorizationSuccess -> {
+                        if (!originalPrincipalAuthorizationSuccess){
+                            throw new RestException(Status.UNAUTHORIZED,
+                                    String.format("Original principal not authorized for super-user operation "
+                                                    + "(original:%s)", originalPrincipal));
+                        }
+                        if (log.isDebugEnabled()) {
+                            log.debug("Successfully authorized {} (proxied by {}) as super-user",
+                                    originalPrincipal, appId);
+                        }
+                    });
+        } else {
+            return pulsar.getBrokerService()
+                    .getAuthorizationService()
+                    .isSuperUser(appId, clientAuthData())
+                    .thenAccept(proxyAuthorizationSuccess -> {
+                        if (!proxyAuthorizationSuccess) {
+                            throw new RestException(Status.UNAUTHORIZED,
+                                    "This operation requires super-user access");
+                        }
+                    });
+        }
     }
 
     /**
@@ -331,77 +331,59 @@ public abstract class PulsarWebResource {
                         if (!isClientAuthenticated(clientAppId)) {
                             throw new RestException(Status.FORBIDDEN, "Need to authenticate to perform the request");
                         }
-                        return validateOriginalPrincipalAsync(clientAppId, originalPrincipal)
-                                .thenCompose(__ -> {
-                                    if (pulsar.getConfiguration().getProxyRoles().contains(clientAppId)) {
-                                        AuthorizationService authorizationService =
-                                                pulsar.getBrokerService().getAuthorizationService();
-                                        return authorizationService.isTenantAdmin(tenant, clientAppId, tenantInfo,
-                                                        authenticationData)
-                                                .thenCompose(isTenantAdmin -> {
-                                                    String debugMsg =
-                                                            "Successfully authorized {} (proxied by {}) on tenant {}";
-                                                    if (!isTenantAdmin) {
-                                                        return authorizationService.isSuperUser(clientAppId,
-                                                                        authenticationData)
-                                                                .thenCombine(authorizationService.isSuperUser(
-                                                                                originalPrincipal,
-                                                                                authenticationData),
-                                                                        (proxyAuthorized,
-                                                                         originalPrincipalAuthorized) -> {
-                                                                            if (!proxyAuthorized
-                                                                                    || !originalPrincipalAuthorized) {
-                                                                                throw new RestException(
-                                                                                        Status.UNAUTHORIZED,
-                                                                                        String.format(
-                                                                                                "Proxy not authorized"
-                                                                                                        + " to access "
-                                                                                                        + "resource "
-                                                                                                        + "(proxy:%s,"
-                                                                                                        + "original:%s)"
-                                                                                                , clientAppId,
-                                                                                                originalPrincipal));
-                                                                            } else {
-                                                                                if (log.isDebugEnabled()) {
-                                                                                    log.debug(debugMsg,
-                                                                                            originalPrincipal,
-                                                                                            clientAppId,
-                                                                                            tenant);
-                                                                                }
-                                                                                return null;
-                                                                            }
-                                                                        });
-                                                    } else {
-                                                        if (log.isDebugEnabled()) {
-                                                            log.debug(debugMsg, originalPrincipal, clientAppId, tenant);
-                                                        }
-                                                        return CompletableFuture.completedFuture(null);
-                                                    }
-                                                });
+                        validateOriginalPrincipal(clientAppId, originalPrincipal);
+                        if (pulsar.getConfiguration().getProxyRoles().contains(clientAppId)) {
+                            AuthorizationService authorizationService =
+                                    pulsar.getBrokerService().getAuthorizationService();
+                            return authorizationService.isTenantAdmin(tenant, clientAppId, tenantInfo,
+                                            authenticationData)
+                                .thenCompose(isTenantAdmin -> {
+                                    String debugMsg = "Successfully authorized {} (proxied by {}) on tenant {}";
+                                    if (!isTenantAdmin) {
+                                            return authorizationService.isSuperUser(clientAppId, authenticationData)
+                                                .thenCombine(authorizationService.isSuperUser(originalPrincipal,
+                                                             authenticationData),
+                                                     (proxyAuthorized, originalPrincipalAuthorized) -> {
+                                                         if (!proxyAuthorized || !originalPrincipalAuthorized) {
+                                                             throw new RestException(Status.UNAUTHORIZED,
+                                                                     String.format("Proxy not authorized to access "
+                                                                                     + "resource (proxy:%s,original:%s)"
+                                                                             , clientAppId, originalPrincipal));
+                                                         } else {
+                                                             if (log.isDebugEnabled()) {
+                                                                 log.debug(debugMsg, originalPrincipal, clientAppId,
+                                                                         tenant);
+                                                             }
+                                                             return null;
+                                                         }
+                                                     });
                                     } else {
-                                        return pulsar.getBrokerService()
-                                                .getAuthorizationService()
-                                                .isSuperUser(clientAppId, authenticationData)
-                                                .thenCompose(isSuperUser -> {
-                                                    if (!isSuperUser) {
-                                                        return pulsar.getBrokerService().getAuthorizationService()
-                                                                .isTenantAdmin(tenant, clientAppId, tenantInfo,
-                                                                        authenticationData);
-                                                    } else {
-                                                        return CompletableFuture.completedFuture(true);
-                                                    }
-                                                }).thenAccept(authorized -> {
-                                                    if (!authorized) {
-                                                        throw new RestException(Status.UNAUTHORIZED,
-                                                                "Don't have permission to administrate resources on "
-                                                                        + "this tenant");
-                                                    } else {
-                                                        log.debug("Successfully authorized {} on tenant {}",
-                                                                clientAppId, tenant);
-                                                    }
-                                                });
+                                        if (log.isDebugEnabled()) {
+                                            log.debug(debugMsg, originalPrincipal, clientAppId, tenant);
+                                        }
+                                        return CompletableFuture.completedFuture(null);
                                     }
                                 });
+                        } else {
+                            return pulsar.getBrokerService()
+                                    .getAuthorizationService()
+                                    .isSuperUser(clientAppId, authenticationData)
+                                    .thenCompose(isSuperUser -> {
+                                        if (!isSuperUser) {
+                                            return pulsar.getBrokerService().getAuthorizationService()
+                                                    .isTenantAdmin(tenant, clientAppId, tenantInfo, authenticationData);
+                                        } else {
+                                            return CompletableFuture.completedFuture(true);
+                                        }
+                                    }).thenAccept(authorized -> {
+                                        if (!authorized) {
+                                            throw new RestException(Status.UNAUTHORIZED,
+                                                    "Don't have permission to administrate resources on this tenant");
+                                        } else {
+                                            log.debug("Successfully authorized {} on tenant {}", clientAppId, tenant);
+                                        }
+                                    });
+                        }
                     } else {
                         return CompletableFuture.completedFuture(null);
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -186,12 +186,14 @@ public abstract class PulsarWebResource {
         return appId != null;
     }
 
-    private void validateOriginalPrincipal(String authenticatedPrincipal, String originalPrincipal) {
+    private CompletableFuture<Void> validateOriginalPrincipalAsync(String authenticatedPrincipal,
+                                                                   String originalPrincipal) {
         if (!pulsar.getBrokerService().getAuthorizationService()
                 .isValidOriginalPrincipal(authenticatedPrincipal, originalPrincipal, clientAuthData())) {
-            throw new RestException(Status.UNAUTHORIZED,
-                    "Invalid combination of Original principal cannot be empty if the request is via proxy.");
+            return FutureUtil.failedFuture(new RestException(Status.UNAUTHORIZED,
+                    "Invalid combination of Original principal cannot be empty if the request is via proxy."));
         }
+        return CompletableFuture.completedFuture(null);
     }
 
     protected boolean hasSuperUserAccess() {
@@ -213,42 +215,46 @@ public abstract class PulsarWebResource {
                     isClientAuthenticated(appId), appId);
         }
         String originalPrincipal = originalPrincipal();
-        validateOriginalPrincipal(appId, originalPrincipal);
-
-        if (pulsar.getConfiguration().getProxyRoles().contains(appId)) {
-            BrokerService brokerService = pulsar.getBrokerService();
-            return brokerService.getAuthorizationService().isSuperUser(appId, clientAuthData())
-                    .thenCompose(proxyAuthorizationSuccess -> {
-                        if (!proxyAuthorizationSuccess){
-                            throw new RestException(Status.UNAUTHORIZED,
-                                    String.format("Proxy not authorized for super-user "
-                                            + "operation (proxy:%s)", appId));
-                        }
+        return validateOriginalPrincipalAsync(appId, originalPrincipal)
+                .thenCompose(__ -> {
+                    if (pulsar.getConfiguration().getProxyRoles().contains(appId)) {
+                        BrokerService brokerService = pulsar.getBrokerService();
+                        return brokerService.getAuthorizationService().isSuperUser(appId, clientAuthData())
+                                .thenCompose(proxyAuthorizationSuccess -> {
+                                    if (!proxyAuthorizationSuccess) {
+                                        return FutureUtil.failedFuture(new RestException(Status.UNAUTHORIZED,
+                                                String.format("Proxy not authorized for super-user "
+                                                        + "operation (proxy:%s)", appId)));
+                                    }
+                                    return pulsar.getBrokerService()
+                                            .getAuthorizationService()
+                                            .isSuperUser(originalPrincipal, clientAuthData());
+                                }).thenCompose(originalPrincipalAuthorizationSuccess -> {
+                                    if (!originalPrincipalAuthorizationSuccess) {
+                                        return FutureUtil.failedFuture(new RestException(Status.UNAUTHORIZED,
+                                                String.format(
+                                                        "Original principal not authorized for super-user operation "
+                                                                + "(original:%s)", originalPrincipal)));
+                                    }
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("Successfully authorized {} (proxied by {}) as super-user",
+                                                originalPrincipal, appId);
+                                    }
+                                    return CompletableFuture.completedFuture(null);
+                                });
+                    } else {
                         return pulsar.getBrokerService()
                                 .getAuthorizationService()
-                                .isSuperUser(originalPrincipal, clientAuthData());
-                    }).thenAccept(originalPrincipalAuthorizationSuccess -> {
-                        if (!originalPrincipalAuthorizationSuccess){
-                            throw new RestException(Status.UNAUTHORIZED,
-                                    String.format("Original principal not authorized for super-user operation "
-                                                    + "(original:%s)", originalPrincipal));
-                        }
-                        if (log.isDebugEnabled()) {
-                            log.debug("Successfully authorized {} (proxied by {}) as super-user",
-                                    originalPrincipal, appId);
-                        }
-                    });
-        } else {
-            return pulsar.getBrokerService()
-                    .getAuthorizationService()
-                    .isSuperUser(appId, clientAuthData())
-                    .thenAccept(proxyAuthorizationSuccess -> {
-                        if (!proxyAuthorizationSuccess) {
-                            throw new RestException(Status.UNAUTHORIZED,
-                                    "This operation requires super-user access");
-                        }
-                    });
-        }
+                                .isSuperUser(appId, clientAuthData())
+                                .thenCompose(proxyAuthorizationSuccess -> {
+                                    if (!proxyAuthorizationSuccess) {
+                                        return FutureUtil.failedFuture(new RestException(Status.UNAUTHORIZED,
+                                                "This operation requires super-user access"));
+                                    }
+                                    return CompletableFuture.completedFuture(null);
+                                });
+                    }
+                });
     }
 
     /**
@@ -319,67 +325,88 @@ public abstract class PulsarWebResource {
         return pulsar.getPulsarResources().getTenantResources().getTenantAsync(tenant)
                 .thenCompose(tenantInfoOptional -> {
                     if (tenantInfoOptional.isEmpty()) {
-                        throw new RestException(Status.NOT_FOUND, "Tenant does not exist");
+                        return FutureUtil.failedFuture(new RestException(Status.NOT_FOUND, "Tenant does not exist"));
                     }
                     TenantInfo tenantInfo = tenantInfoOptional.get();
                     if (pulsar.getConfiguration().isAuthenticationEnabled() && pulsar.getConfiguration()
                             .isAuthorizationEnabled()) {
                         if (!isClientAuthenticated(clientAppId)) {
-                            throw new RestException(Status.FORBIDDEN, "Need to authenticate to perform the request");
+                            return FutureUtil.failedFuture(new RestException(Status.FORBIDDEN,
+                                    "Need to authenticate to perform the request"));
                         }
-                        validateOriginalPrincipal(clientAppId, originalPrincipal);
-                        if (pulsar.getConfiguration().getProxyRoles().contains(clientAppId)) {
-                            AuthorizationService authorizationService =
-                                    pulsar.getBrokerService().getAuthorizationService();
-                            return authorizationService.isTenantAdmin(tenant, clientAppId, tenantInfo,
-                                            authenticationData)
-                                .thenCompose(isTenantAdmin -> {
-                                    String debugMsg = "Successfully authorized {} (proxied by {}) on tenant {}";
-                                    if (!isTenantAdmin) {
-                                            return authorizationService.isSuperUser(clientAppId, authenticationData)
-                                                .thenCombine(authorizationService.isSuperUser(originalPrincipal,
-                                                             authenticationData),
-                                                     (proxyAuthorized, originalPrincipalAuthorized) -> {
-                                                         if (!proxyAuthorized || !originalPrincipalAuthorized) {
-                                                             throw new RestException(Status.UNAUTHORIZED,
-                                                                     String.format("Proxy not authorized to access "
-                                                                                     + "resource (proxy:%s,original:%s)"
-                                                                             , clientAppId, originalPrincipal));
-                                                         } else {
-                                                             if (log.isDebugEnabled()) {
-                                                                 log.debug(debugMsg, originalPrincipal, clientAppId,
-                                                                         tenant);
-                                                             }
-                                                             return null;
-                                                         }
-                                                     });
+                        return validateOriginalPrincipalAsync(clientAppId, originalPrincipal)
+                                .thenCompose(__ -> {
+                                    if (pulsar.getConfiguration().getProxyRoles().contains(clientAppId)) {
+                                        AuthorizationService authorizationService =
+                                                pulsar.getBrokerService().getAuthorizationService();
+                                        return authorizationService.isTenantAdmin(tenant, clientAppId, tenantInfo,
+                                                        authenticationData)
+                                                .thenCompose(isTenantAdmin -> {
+                                                    String debugMsg =
+                                                            "Successfully authorized {} (proxied by {}) on tenant {}";
+                                                    if (!isTenantAdmin) {
+                                                        return authorizationService.isSuperUser(clientAppId,
+                                                                        authenticationData)
+                                                                .thenCombine(
+                                                                        authorizationService.isSuperUser(
+                                                                                originalPrincipal,
+                                                                                authenticationData),
+                                                                        (proxyAuthorized, originalPrincipalAuthorized)
+                                                                                -> proxyAuthorized
+                                                                                && originalPrincipalAuthorized)
+                                                                .thenCompose(authorized -> {
+                                                                    if (!authorized) {
+                                                                        String errorMsg =
+                                                                                "Proxy not authorized to access "
+                                                                                        + "resource (proxy:%s,"
+                                                                                        + "original:%s)";
+                                                                        return FutureUtil.failedFuture(
+                                                                                new RestException(
+                                                                                        Status.UNAUTHORIZED,
+                                                                                        String.format(errorMsg,
+                                                                                                clientAppId,
+                                                                                                originalPrincipal)));
+                                                                    }
+                                                                    if (log.isDebugEnabled()) {
+                                                                        log.debug(debugMsg, originalPrincipal,
+                                                                                clientAppId, tenant);
+                                                                    }
+                                                                    return CompletableFuture.completedFuture(null);
+                                                                });
+                                                    } else {
+                                                        if (log.isDebugEnabled()) {
+                                                            log.debug(debugMsg, originalPrincipal, clientAppId, tenant);
+                                                        }
+                                                        return CompletableFuture.completedFuture(null);
+                                                    }
+                                                });
                                     } else {
-                                        if (log.isDebugEnabled()) {
-                                            log.debug(debugMsg, originalPrincipal, clientAppId, tenant);
-                                        }
-                                        return CompletableFuture.completedFuture(null);
+                                        return pulsar.getBrokerService()
+                                                .getAuthorizationService()
+                                                .isSuperUser(clientAppId, authenticationData)
+                                                .thenCompose(isSuperUser -> {
+                                                    if (!isSuperUser) {
+                                                        return pulsar.getBrokerService().getAuthorizationService()
+                                                                .isTenantAdmin(tenant, clientAppId, tenantInfo,
+                                                                        authenticationData);
+                                                    } else {
+                                                        return CompletableFuture.completedFuture(true);
+                                                    }
+                                                }).thenCompose(authorized -> {
+                                                    if (!authorized) {
+                                                        return FutureUtil.failedFuture(
+                                                                new RestException(Status.UNAUTHORIZED,
+                                                                        "Don't have permission to administrate "
+                                                                                + "resources "
+                                                                                + "on this tenant"));
+                                                    } else {
+                                                        log.debug("Successfully authorized {} on tenant {}",
+                                                                clientAppId, tenant);
+                                                        return CompletableFuture.completedFuture(null);
+                                                    }
+                                                });
                                     }
                                 });
-                        } else {
-                            return pulsar.getBrokerService()
-                                    .getAuthorizationService()
-                                    .isSuperUser(clientAppId, authenticationData)
-                                    .thenCompose(isSuperUser -> {
-                                        if (!isSuperUser) {
-                                            return pulsar.getBrokerService().getAuthorizationService()
-                                                    .isTenantAdmin(tenant, clientAppId, tenantInfo, authenticationData);
-                                        } else {
-                                            return CompletableFuture.completedFuture(true);
-                                        }
-                                    }).thenAccept(authorized -> {
-                                        if (!authorized) {
-                                            throw new RestException(Status.UNAUTHORIZED,
-                                                    "Don't have permission to administrate resources on this tenant");
-                                        } else {
-                                            log.debug("Successfully authorized {} on tenant {}", clientAppId, tenant);
-                                        }
-                                    });
-                        }
                     } else {
                         return CompletableFuture.completedFuture(null);
                     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/PulsarCompactionServiceFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/PulsarCompactionServiceFactory.java
@@ -19,13 +19,13 @@
 package org.apache.pulsar.compaction;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -61,14 +61,18 @@ public class PulsarCompactionServiceFactory implements CompactionServiceFactory 
 
     @Override
     public CompletableFuture<Void> initialize(@NonNull PulsarService pulsarService) {
-        Objects.requireNonNull(pulsarService);
+        if (pulsarService == null) {
+            return FutureUtil.failedFuture(new NullPointerException("Expected pulsarService should not be null"));
+        }
         this.pulsarService = pulsarService;
         return CompletableFuture.completedFuture(null);
     }
 
     @Override
     public CompletableFuture<TopicCompactionService> newTopicCompactionService(@NonNull String topic) {
-        Objects.requireNonNull(topic);
+        if (topic == null) {
+            return FutureUtil.failedFuture(new NullPointerException("Expected topic should not be null"));
+        }
         PulsarTopicCompactionService pulsarTopicCompactionService =
                 new PulsarTopicCompactionService(topic, pulsarService.getBookKeeperClient(), () -> {
                     try {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
@@ -76,7 +76,7 @@ public class StrategicTwoPhaseCompactor extends PublishingOrderCompactor {
     }
 
     public CompletableFuture<Long> compact(String topic) {
-        throw new UnsupportedOperationException();
+        return CompletableFuture.failedFuture(new UnsupportedOperationException());
     }
 
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/StrategicTwoPhaseCompactor.java
@@ -76,7 +76,7 @@ public class StrategicTwoPhaseCompactor extends PublishingOrderCompactor {
     }
 
     public CompletableFuture<Long> compact(String topic) {
-        return CompletableFuture.failedFuture(new UnsupportedOperationException());
+        return FutureUtil.failedFuture(new UnsupportedOperationException());
     }
 
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
@@ -39,10 +39,10 @@ import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.protocol.ByteBufPair;
 import org.apache.pulsar.common.protocol.Commands;
 import org.apache.pulsar.common.protocol.FrameDecoderUtil;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.PulsarSslConfiguration;
 import org.apache.pulsar.common.util.PulsarSslFactory;
 import org.apache.pulsar.common.util.SecurityUtility;
-import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.netty.NettyFutureUtil;
 
 @Slf4j

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarChannelInitializer.java
@@ -27,7 +27,6 @@ import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.handler.ssl.SslHandler;
 import java.net.InetSocketAddress;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -43,6 +42,7 @@ import org.apache.pulsar.common.protocol.FrameDecoderUtil;
 import org.apache.pulsar.common.util.PulsarSslConfiguration;
 import org.apache.pulsar.common.util.PulsarSslFactory;
 import org.apache.pulsar.common.util.SecurityUtility;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.netty.NettyFutureUtil;
 
 @Slf4j
@@ -106,10 +106,14 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
      * @return a {@link CompletableFuture} that completes when the TLS is set up.
      */
     CompletableFuture<Channel> initTls(Channel ch, InetSocketAddress sniHost) {
-        Objects.requireNonNull(ch, "A channel is required");
-        Objects.requireNonNull(sniHost, "A sniHost is required");
+        if (ch == null) {
+            return FutureUtil.failedFuture(new NullPointerException("A channel is required"));
+        }
+        if (sniHost == null) {
+            return FutureUtil.failedFuture(new NullPointerException("A sniHost is required"));
+        }
         if (!tlsEnabled) {
-            throw new IllegalStateException("TLS is not enabled in client configuration");
+            return FutureUtil.failedFuture(new IllegalStateException("TLS is not enabled in client configuration"));
         }
         CompletableFuture<Channel> initTlsFuture = new CompletableFuture<>();
         ch.eventLoop().execute(() -> {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -227,7 +227,8 @@ public class FutureUtil {
         }
 
         /**
-         * @throws NullPointerException NPE when param is null
+         * @return a {@link CompletableFuture} representing the newly scheduled task,
+         * or a completed exceptionally with {@link NullPointerException} if param is null,
          */
         public synchronized CompletableFuture<T> sequential(Supplier<CompletableFuture<T>> newTask) {
             if (newTask == null) {
@@ -283,13 +284,17 @@ public class FutureUtil {
     }
 
     /**
-     * @throws RejectedExecutionException if this task cannot be accepted for execution
-     * @throws NullPointerException if one of params is null
+     * @return a {@link CompletableFuture} representing the asynchronous composition.
+     * The returned future is completed exceptionally with {@link NullPointerException} if one of params is null,
+     * or with {@link RejectedExecutionException} if the task cannot be accepted for execution.
      */
     public static <T> @NonNull CompletableFuture<T> composeAsync(Supplier<CompletableFuture<T>> futureSupplier,
                                                                  Executor executor) {
-        if (futureSupplier == null || executor == null) {
-            return failedFuture(new NullPointerException());
+        if (futureSupplier == null) {
+            return failedFuture(new NullPointerException("Expected Supplier should not be null"));
+        }
+        if (executor == null) {
+            return failedFuture(new NullPointerException("Expected Executor should not be null"));
         }
         final CompletableFuture<T> future = new CompletableFuture<>();
         try {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -228,11 +228,11 @@ public class FutureUtil {
 
         /**
          * @return a {@link CompletableFuture} representing the newly scheduled task,
-         * or a completed exceptionally with {@link NullPointerException} if param is null,
+         * or a completed exceptionally with {@link NullPointerException} if param is null.
          */
         public synchronized CompletableFuture<T> sequential(Supplier<CompletableFuture<T>> newTask) {
             if (newTask == null) {
-                return failedFuture(new NullPointerException());
+                return failedFuture(new NullPointerException("Expected Supplier should not be null"));
             }
             if (sequencerFuture.isDone()) {
                 if (sequencerFuture.isCompletedExceptionally() && allowExceptionBreakChain) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -231,7 +230,9 @@ public class FutureUtil {
          * @throws NullPointerException NPE when param is null
          */
         public synchronized CompletableFuture<T> sequential(Supplier<CompletableFuture<T>> newTask) {
-            Objects.requireNonNull(newTask);
+            if (newTask == null) {
+                return failedFuture(new NullPointerException());
+            }
             if (sequencerFuture.isDone()) {
                 if (sequencerFuture.isCompletedExceptionally() && allowExceptionBreakChain) {
                     return sequencerFuture;
@@ -287,8 +288,9 @@ public class FutureUtil {
      */
     public static <T> @NonNull CompletableFuture<T> composeAsync(Supplier<CompletableFuture<T>> futureSupplier,
                                                                  Executor executor) {
-        Objects.requireNonNull(futureSupplier);
-        Objects.requireNonNull(executor);
+        if (futureSupplier == null || executor == null) {
+            return failedFuture(new NullPointerException());
+        }
         final CompletableFuture<T> future = new CompletableFuture<>();
         try {
             executor.execute(() -> futureSupplier.get().whenComplete((result, error) -> {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FutureUtil.java
@@ -228,7 +228,7 @@ public class FutureUtil {
 
         /**
          * @return a {@link CompletableFuture} representing the newly scheduled task,
-         * or a completed exceptionally with {@link NullPointerException} if param is null.
+         * or one completed exceptionally with {@link NullPointerException} if param is null.
          */
         public synchronized CompletableFuture<T> sequential(Supplier<CompletableFuture<T>> newTask) {
             if (newTask == null) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/ChannelFutures.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/ChannelFutures.java
@@ -20,8 +20,8 @@ package org.apache.pulsar.common.util.netty;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.common.util.FutureUtil;
 
 /**
  * Static utility methods for operating on {@link ChannelFuture}s.
@@ -41,7 +41,9 @@ public class ChannelFutures {
      *         and completes exceptionally if the channelFuture completes with a {@link Throwable}
      */
     public static CompletableFuture<Channel> toCompletableFuture(ChannelFuture channelFuture) {
-        Objects.requireNonNull(channelFuture, "channelFuture cannot be null");
+        if (channelFuture == null) {
+            return FutureUtil.failedFuture(new NullPointerException("channelFuture cannot be null"));
+        }
 
         CompletableFuture<Channel> adapter = new CompletableFuture<>();
         if (channelFuture.isDone()) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/NettyFutureUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/NettyFutureUtil.java
@@ -19,8 +19,8 @@
 package org.apache.pulsar.common.util.netty;
 
 import io.netty.util.concurrent.Future;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.common.util.FutureUtil;
 
 /**
  * Contains utility methods for working with Netty Futures.
@@ -34,7 +34,9 @@ public class NettyFutureUtil {
      * @return converted future instance
      */
     public static <V> CompletableFuture<V> toCompletableFuture(Future<V> future) {
-        Objects.requireNonNull(future, "future cannot be null");
+        if (future == null) {
+            return FutureUtil.failedFuture(new NullPointerException("future cannot be null"));
+        }
 
         CompletableFuture<V> adapter = new CompletableFuture<>();
         if (future.isDone()) {
@@ -62,7 +64,9 @@ public class NettyFutureUtil {
      * @return converted future instance
      */
     public static CompletableFuture<Void> toCompletableFutureVoid(Future<?> future) {
-        Objects.requireNonNull(future, "future cannot be null");
+        if (future == null) {
+            return FutureUtil.failedFuture(new NullPointerException("future cannot be null"));
+        }
 
         CompletableFuture<Void> adapter = new CompletableFuture<>();
         if (future.isDone()) {

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/netty/ChannelFuturesTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/netty/ChannelFuturesTest.java
@@ -23,6 +23,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.DefaultEventLoop;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.mockito.Mock;
@@ -65,9 +66,16 @@ public class ChannelFuturesTest {
         channelFuture = new DefaultChannelPromise(channel);
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void toCompletableFuture_shouldRequireNonNullArgument() {
-        ChannelFutures.toCompletableFuture(null);
+        CompletableFuture<Channel> future = ChannelFutures.toCompletableFuture(null);
+        Assert.assertTrue(future.isCompletedExceptionally());
+        try {
+            future.join();
+            Assert.fail("Expected NullPointerException");
+        } catch (CompletionException e) {
+            Assert.assertTrue(e.getCause() instanceof NullPointerException);
+        }
     }
 
     @Test


### PR DESCRIPTION
same to this pr https://github.com/apache/pulsar/pull/25287

### Motivation

In Java's CompletableFuture, callbacks registered via stages such as thenApply, thenCompose, etc., are executed within internal try/catch blocks. If a callback throws an exception, the framework automatically captures it and completes the dependent future exceptionally.

Therefore, throwing an exception inside a stage callback is safe and will be translated into an exceptionally completed future.

However, if an async method itself throws an exception instead of returning a failed future, the exception is raised synchronously and no CompletableFuture is returned. This breaks the expected async error propagation model.

Some async validation paths in the broker currently throw exceptions directly instead of returning a failed CompletableFuture. This breaks the async contract of methods that return CompletableFuture, because the exception is thrown synchronously at invocation time rather than being propagated through the future.

As a result, callers relying on async error handling (e.g. exceptionally, handle, or whenComplete) may not observe these failures correctly.

### Modifications

1. Convert validation synchronous throws to failed futures in broker async methods.
2. Refactor original-principal validation to an async helper and preserve original auth/authorization semantics.
3. Ensure default async UnsupportedOperationException paths return failed futures.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
